### PR TITLE
Minor fixes

### DIFF
--- a/gbcs-parser.html
+++ b/gbcs-parser.html
@@ -22,8 +22,8 @@
 <style>
 body { background-color: #fff; color: #000; font-family: monospace; }
 h1 { color: #009ee2; }
-h1 > a, h1 > a:visited { text-decoration: none; color: inherit; }
-textarea { width: 100%; }
+a.plain, a.plain:visited { text-decoration: none; color: inherit; }
+textarea { width: 100%; resize: vertical; }
 table { border-collapse: collapse; table-layout: fixed; width: 100%; }
 tr:nth-child(odd) { background-color: #f0f8ff; }
 th { border: 1px solid #009ee2; background-color: #009ee2; color: #fff; font-weight: bold; }
@@ -31,8 +31,8 @@ td { border: 1px solid #009ee2; padding: 1px 2px; vertical-align: top; white-spa
 </style>
 </head>
 <body>
-<h1><a href="">GBCS Message Parser</a></h1>
-<p><textarea id=textarea placeholder="Paste here the hex string of the GBCS message" autofocus></textarea>
+<h1><a class="plain" href="">GBCS Message Parser</a></h1>
+<p><textarea id="textarea" rows="7" placeholder="Paste here the hex string of the GBCS message" autofocus></textarea>
 <p><button type=button onclick=parse()>Parse</button>
 <p><table id=table></table>
 <p>GBCS V3.1 Use Cases: <a href=https://henrygiraldo.github.io/gbcs-parser-js/gbcs-use-cases.html>https://henrygiraldo.github.io/gbcs-parser-js/gbcs-use-cases.html</a>
@@ -65,7 +65,7 @@ function parseGbcsMessage(text) {
       var gbt = [];
       do {
         var block = parseGeneralBlockTransfer(x);
-        if (block.number > 0) {
+        if (block.number > 0 && block.len > 0) {
           gbt[block.number - 1] = block;
         }
       } while (x.index < x.end);
@@ -201,7 +201,7 @@ function parseGbcsMessage(text) {
           break;
         }
       }
-      putSeparator("GBT Reconstructed Data");
+      putSeparator("<a class=\"plain\" href=\"#" + full + "\">GBT Reconstructed Data</a>");
       output += parseGbcsMessage(full);
     }
   }
@@ -1565,7 +1565,7 @@ function parseGbcsMessage(text) {
     if (indent == undefined) {
       indent = "";
     }
-    putBytes("Compact Array", getBytes(x, 1));
+    putBytes(name, getBytes(x, 1));
     var typeDescriptionLen = parseDlmsTypeDescription(x, x.index);
     putBytes(indent + " Type Description", getBytes(x, typeDescriptionLen));
     var arrayContentsLen = x.input[x.index];
@@ -1583,11 +1583,11 @@ function parseGbcsMessage(text) {
     var typeDescriptionLength = 1;
     var choice = x.input[index];
     if (choice == 1) {  // array
-      var numberOfElements = x.input[index + 1] * 256 + x.input[x.index + 2];
+      //var numberOfElements = x.input[index + 1] * 256 + x.input[index + 2];
       typeDescriptionLength += 2;
-      typeDescriptionLength += numberOfElements * parseDlmsTypeDescription(x, index + typeDescriptionLength);
+      typeDescriptionLength += parseDlmsTypeDescription(x, index + typeDescriptionLength);
     } else if (choice == 2) {  // structure
-      var n = x.input[x.index + 1];
+      var n = x.input[index + 1];
       typeDescriptionLength += 1;
       for (var i = 0; i < n; i++) {
         typeDescriptionLength += parseDlmsTypeDescription(x, index + typeDescriptionLength);

--- a/gbcs-parser.html
+++ b/gbcs-parser.html
@@ -225,7 +225,7 @@ function parseGbcsMessage(text) {
         if (otherInfoLen == 26) {
           parseCounter("Supplementary Originator Counter", otherInfo);
         } else if (otherInfoLen > 26) {
-          putBytes("Supplementary Remote Party Key Agreement Certificate", otherInfo);
+          parseCertificate(otherInfo, "Supplementary Remote Party Key Agreement Certificate");
         }
       }
     }
@@ -1195,7 +1195,7 @@ function parseGbcsMessage(text) {
     return getLink(name, url);
   }
 
-  function parseCertificate(x) {
+  function parseCertificate(x, name) {
     var length = x.input[x.index + 1];
     var header = 2;
     if (length == 0x81) {
@@ -1206,7 +1206,7 @@ function parseGbcsMessage(text) {
       header = 4;
     }
     var decoder = getCertificateDecoder("Decode certificate", x, header + length);
-    putBytes("Certificate", getBytes(x, header + length), decoder);
+    putBytes(name || "Certificate", getBytes(x, header + length), decoder);
   }
 
   // ASN.1 Types


### PR DESCRIPTION
* Plain hyperlink styles.
* Textarea is now only vertically resizeable and bigger by default.
* GBT: do not take into account blocks with no data (ACKs) when reconstructing the full frame.
* Parse as certificate the Supplementary Remote Party Key Agreement Certificate.
* Fixes in parser of DLMS compact array.