### PR TITLE
Use new ssldecoder instance

### DIFF
--- a/gbcs-parser.html
+++ b/gbcs-parser.html
@@ -1552,7 +1552,7 @@ function parseGbcsMessage(text) {
   function getCertificateDecoder(name, x, n) {
     var bin = x.input.slice(x.index, x.index + n);
     var base64 = btoa(String.fromCharCode.apply(null, bin));
-    var url = "https://ssldecoder.org/?csr=-----BEGIN+CERTIFICATE-----%0D%0A" + encodeURIComponent(base64) + "%0D%0A-----END+CERTIFICATE-----";
+    var url = "https://ssldecoder.daniel-ruf.de/?csr=-----BEGIN+CERTIFICATE-----%0D%0A" + encodeURIComponent(base64) + "%0D%0A-----END+CERTIFICATE-----";
     return getLink(name, url);
   }
 


### PR DESCRIPTION
See https://raymii.org/s/blog/Cancellation_notice_for_cipherlist_ssldecoder_and_certificatemonitor.html

As alternative solutions I have setup https://cipherlist.daniel-ruf.de and https://ssldecoder.daniel-ruf.de and I plan to manage them for a long time.